### PR TITLE
FISH-867 Servlet TCK Failure Isolated Fix

### DIFF
--- a/appserver/web/web-glue/src/main/java/com/sun/enterprise/security/web/GlassFishSingleSignOn.java
+++ b/appserver/web/web-glue/src/main/java/com/sun/enterprise/security/web/GlassFishSingleSignOn.java
@@ -56,6 +56,7 @@ import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -471,11 +472,17 @@ public class GlassFishSingleSignOn extends SingleSignOn
         // SSO entries. However, this should be addressed separately.
 
         try {
-            this.cache.forEach((ssoId, sso) -> {
-                if (sso.isEmpty() && sso.getLastAccessTime() < tooOld) {
-                    removals.add(ssoId);
+            synchronized (cache) {
+
+                Iterator<String> it = cache.keySet().iterator();
+                while (it.hasNext()) {
+                    String key = it.next();
+                    SingleSignOnEntry sso = (SingleSignOnEntry) cache.get(key);
+                    if (sso.isEmpty() && sso.getLastAccessTime() < tooOld) {
+                        removals.add(key);
+                    }
                 }
-            });
+            }
 
             int removalCount = removals.size();
             // S1AS8 6155481 START


### PR DESCRIPTION
Partial revert of b298f292cd383ea3aab7ad244f0d4ce649a6a4e9
(https://github.com/payara/Payara/pull/4479/commits/b298f292cd383ea3aab7ad244f0d4ce649a6a4e9)

3 Servlet failures were caused by an 'unauthorized' error.
This reverts part of the PR that removed locking from the SSO store.

Signed-off-by: Matthew Gill <matthew.gill@live.co.uk>